### PR TITLE
Criado servicos de dados do dashboard

### DIFF
--- a/src/app/dashboard/dados.service.spec.ts
+++ b/src/app/dashboard/dados.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { DadosService } from './dados.service';
+
+describe('DadosService', () => {
+  let service: DadosService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(DadosService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/dashboard/dados.service.ts
+++ b/src/app/dashboard/dados.service.ts
@@ -1,0 +1,9 @@
+import { Injectable } from '@angular/core';
+
+@Injectable({
+  providedIn: 'root'
+})
+export class DadosService {
+
+  constructor() { }
+}

--- a/src/app/dashboard/dashboard.component.spec.ts
+++ b/src/app/dashboard/dashboard.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { DashboardComponent } from './dashboard.component';
+import { DadosService } from './dados.service';
 
 describe('DashboardComponent', () => {
   let component: DashboardComponent;
@@ -8,7 +9,8 @@ describe('DashboardComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ DashboardComponent ]
+      declarations: [ DashboardComponent ],
+      providers: [ DadosService ]
     })
     .compileComponents();
   });

--- a/src/app/dashboard/dashboard.module.ts
+++ b/src/app/dashboard/dashboard.module.ts
@@ -1,6 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { DashboardComponent } from './dashboard.component';
+import { DadosService } from './dados.service';
 
 
 
@@ -14,6 +15,9 @@ import { DashboardComponent } from './dashboard.component';
   ],
   imports: [
     CommonModule
+  ],
+  providers: [
+    DadosService
   ]
 })
 export class DashboardModule { }

--- a/src/app/dashboard/index.ts
+++ b/src/app/dashboard/index.ts
@@ -1,2 +1,3 @@
 export * from './dashboard.module'; //export do arquivo dashboard.module
 export * from './dashboard.component'; //export do arquivo dashboard.component
+export * from './dados.service'; //export do dados.Service


### PR DESCRIPTION
Gerado o serviços de dados do dashboard para rederizar os gráficos, foi usado o comando: ng g service dashboard/dados  (Foi gerado 2 arquivos de dados.service).
Foi add:
- Export do dados.service no arquivo index.ts da pasta dashboard.
- O import do DadosService no arquivo dashboard.module.ts com providers junto.
- O import do DadosService no arquivo dashboard.module.spec.ts com providers.